### PR TITLE
Introduce 'clean' target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
 .PHONY: build-osx
 build-osx:
 	GOOS=darwin GOARCH=arm64 go build -o build/lc .
+
+.PHONY: clean
+clean:
+	rm -rf build


### PR DESCRIPTION
This pull request introduces changes made in commit `420db57c174caf06c63a53c5bbf73b88882271c9`.

The main update is the addition of a 'clean' target to the Makefile. The purpose of this target is to provide an easy and quick way to remove previously built files from the build directory. This can make the development process smoother and more efficient.

Before merging, please ensure that these changes have been thoroughly reviewed and tested.

Please feel free to leave a comment or contact me directly if there are any specific points you wish to discuss or if there's anything unclear.

Thank you!